### PR TITLE
타운 생성 관련 주석 수정, 내 옷장 아이템 조회 및 코디 이미지로 프로필 업데이트 기능 추가

### DIFF
--- a/src/main/java/com/themore/moamoatown/common/exception/ErrorCode.java
+++ b/src/main/java/com/themore/moamoatown/common/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     TOWN_CREATE_FAILED(BAD_REQUEST, "타운 만들기에 실패했습니다."),
     WORD_INSERT_FAILED(INTERNAL_SERVER_ERROR, "단어 삽입에 실패했습니다."),
     GPT_REQUEST_FAILED(INTERNAL_SERVER_ERROR, "GPT 요청에 실패했습니다."),
+    UPDATE_PROFILE_FAILED(INTERNAL_SERVER_ERROR, "프로필 변경에 실패했습니다")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/themore/moamoatown/coordi/controller/CoordiController.java
+++ b/src/main/java/com/themore/moamoatown/coordi/controller/CoordiController.java
@@ -1,0 +1,58 @@
+package com.themore.moamoatown.coordi.controller;
+
+import com.themore.moamoatown.common.annotation.MemberId;
+import com.themore.moamoatown.coordi.dto.MyClothesResponseDTO;
+import com.themore.moamoatown.coordi.dto.UpdateProfileRequestDTO;
+import com.themore.moamoatown.coordi.service.CoordiService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 코디 컨트롤러
+ * @author 임원정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	임원정        최초 생성
+ * 
+ * </pre>
+ */
+
+@Log4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value="/coordi",
+        produces = "application/json; charset=UTF-8")
+public class CoordiController {
+    private final CoordiService coordiService;
+
+    /**
+     * 내가 구매한 옷 조회
+     * @param memberId
+     * @return
+     */
+    @GetMapping("/myclothes")
+    public ResponseEntity<List<MyClothesResponseDTO>> getMyClothes(@MemberId Long memberId) {
+        List<MyClothesResponseDTO> response = coordiService.getMyClothes(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 코디한 이미지로 프로필 업데이트
+     * @param requestDTO
+     * @param memberId
+     * @return
+     */
+    @PostMapping("/update")
+    public ResponseEntity<String> updateProfile(@RequestBody UpdateProfileRequestDTO requestDTO, @MemberId Long memberId) {
+        coordiService.updateProfile(requestDTO, memberId);
+        return ResponseEntity.ok("프로필이 성공적으로 변경되었습니다.");
+    }
+}

--- a/src/main/java/com/themore/moamoatown/coordi/dto/MyClothesResponseDTO.java
+++ b/src/main/java/com/themore/moamoatown/coordi/dto/MyClothesResponseDTO.java
@@ -1,0 +1,31 @@
+package com.themore.moamoatown.coordi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 내 옷장 옷 리스트 Response DTO
+ * @author 임원정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	임원정        최초 생성
+ * </pre>
+ */
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyClothesResponseDTO {
+    private Long clothId;
+    private String brand;
+    private String name;
+    private Long type;
+    private String imgUrl;
+}

--- a/src/main/java/com/themore/moamoatown/coordi/dto/UpdateProfileInternalDTO.java
+++ b/src/main/java/com/themore/moamoatown/coordi/dto/UpdateProfileInternalDTO.java
@@ -1,0 +1,28 @@
+package com.themore.moamoatown.coordi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 프로필 업데이트 내부 DTO
+ * @author 임원정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	임원정        최초 생성
+ * </pre>
+ */
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateProfileInternalDTO {
+    private Long memberId;
+    private byte[] profileImage;
+}

--- a/src/main/java/com/themore/moamoatown/coordi/dto/UpdateProfileRequestDTO.java
+++ b/src/main/java/com/themore/moamoatown/coordi/dto/UpdateProfileRequestDTO.java
@@ -1,0 +1,27 @@
+package com.themore.moamoatown.coordi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 프로필 업데이트 Request DTO
+ * @author 임원정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	임원정        최초 생성
+ * </pre>
+ */
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateProfileRequestDTO {
+    private String profile; // base64 인코딩된 String
+}

--- a/src/main/java/com/themore/moamoatown/coordi/mapper/CoordiMapper.java
+++ b/src/main/java/com/themore/moamoatown/coordi/mapper/CoordiMapper.java
@@ -1,0 +1,29 @@
+package com.themore.moamoatown.coordi.mapper;
+
+import com.themore.moamoatown.coordi.dto.MyClothesResponseDTO;
+import com.themore.moamoatown.coordi.dto.UpdateProfileInternalDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+/**
+ * 코디 매퍼 인터페이스
+ * @author 임원정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	임원정        최초 생성
+ * 2024.08.25  	임원정        selectClothesByMemberId, updateProfile 메소드 추가
+ * </pre>
+ */
+
+@Mapper
+public interface CoordiMapper {
+    // 내 옷 가져오기
+    List<MyClothesResponseDTO> selectClothesByMemberId(Long memberId);
+    // 프로필 업데이트
+    int updateProfile(UpdateProfileInternalDTO internalDTO);
+}

--- a/src/main/java/com/themore/moamoatown/coordi/service/CoordiService.java
+++ b/src/main/java/com/themore/moamoatown/coordi/service/CoordiService.java
@@ -1,0 +1,27 @@
+package com.themore.moamoatown.coordi.service;
+
+import com.themore.moamoatown.coordi.dto.MyClothesResponseDTO;
+import com.themore.moamoatown.coordi.dto.UpdateProfileRequestDTO;
+
+import java.util.List;
+
+/**
+ * 코디 서비스 인터페이스
+ * @author 임원정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	임원정        최초 생성
+ * 2024.08.25   임원정        getMyClothes, updateProfile 메소드 추가
+ * </pre>
+ */
+
+public interface CoordiService {
+    // 내가 구매한 옷 가져오기
+    List<MyClothesResponseDTO> getMyClothes(Long memberId);
+    // 프로필 업데이트
+    void updateProfile(UpdateProfileRequestDTO requestDTO, Long memberId);
+}

--- a/src/main/java/com/themore/moamoatown/coordi/service/CoordiServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/coordi/service/CoordiServiceImpl.java
@@ -1,0 +1,75 @@
+package com.themore.moamoatown.coordi.service;
+
+import com.themore.moamoatown.common.exception.CustomException;
+import com.themore.moamoatown.coordi.dto.MyClothesResponseDTO;
+import com.themore.moamoatown.coordi.dto.UpdateProfileInternalDTO;
+import com.themore.moamoatown.coordi.dto.UpdateProfileRequestDTO;
+import com.themore.moamoatown.coordi.mapper.CoordiMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.themore.moamoatown.common.exception.ErrorCode.*;
+
+/**
+ * 코디 서비스 구현체
+ * @author 임원정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	임원정        최초 생성
+ * 2024.08.25  	임원정        getMyClothes, updateProfile 메소드 추가
+ * </pre>
+ */
+
+@Log4j
+@Service
+@RequiredArgsConstructor
+public class CoordiServiceImpl implements CoordiService{
+    private final CoordiMapper coordiMapper;
+
+    /**
+     * 내가 구매한 옷 가져오기
+     * @param memberId
+     * @return
+     */
+    @Override
+    @Transactional
+    public List<MyClothesResponseDTO> getMyClothes(Long memberId) {
+        return coordiMapper.selectClothesByMemberId(memberId)
+                .stream()
+                .map(clothes -> MyClothesResponseDTO.builder()
+                        .clothId(clothes.getClothId())
+                        .brand(clothes.getBrand())
+                        .name(clothes.getName())
+                        .type(clothes.getType())
+                        .imgUrl(clothes.getImgUrl())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 프로필 업데이트
+     * @param requestDTO
+     * @param memberId
+     */
+    @Override
+    @Transactional
+    public void updateProfile(UpdateProfileRequestDTO requestDTO, Long memberId) {
+        // byte로 변환
+        byte[] decodedImage = requestDTO.getProfile().getBytes();
+        UpdateProfileInternalDTO internalDTO = UpdateProfileInternalDTO.builder()
+                .memberId(memberId)
+                .profileImage(decodedImage)
+                .build();
+
+        if(coordiMapper.updateProfile(internalDTO)!=1) throw new CustomException(UPDATE_PROFILE_FAILED);
+    }
+}

--- a/src/main/java/com/themore/moamoatown/town/controller/TownController.java
+++ b/src/main/java/com/themore/moamoatown/town/controller/TownController.java
@@ -18,7 +18,7 @@ import javax.servlet.http.HttpSession;
 /**
  * 타운 컨트롤러
  * @author 임원정
- * @since 2024.08.24
+ * @since 2024.08.23
  * @version 1.0
  *
  * <pre>
@@ -33,17 +33,24 @@ import javax.servlet.http.HttpSession;
 @Log4j
 @RestController
 @RequiredArgsConstructor
-//@RequestMapping("/town")
 @RequestMapping(value="/town",
         produces = "application/json; charset=UTF-8")
 public class TownController {
     private final TownService townService;
 
+    /**
+     * 타운 만들기
+     * @param requestDTO
+     * @param memberId
+     * @param session
+     * @return
+     */
     @PostMapping("/create")
     public ResponseEntity<TownCreateResponseDTO> createTown(@RequestBody TownCreateRequestDTO requestDTO, @MemberId Long memberId,
-                                             HttpSession session) throws Exception {
+                                             HttpSession session) {
         // 타운 생성
         TownCreateInternalDTO internalDTO = townService.createTown(requestDTO, memberId);
+
         // 세션에 town_id 저장
         session.setAttribute("town_id", internalDTO.getTownId());
         // response 생성

--- a/src/main/java/com/themore/moamoatown/town/dto/TownCreateInternalDTO.java
+++ b/src/main/java/com/themore/moamoatown/town/dto/TownCreateInternalDTO.java
@@ -26,3 +26,4 @@ public class TownCreateInternalDTO {
     private Long townId;
     private String townCode;
 }
+

--- a/src/main/java/com/themore/moamoatown/town/mapper/TownMapper.java
+++ b/src/main/java/com/themore/moamoatown/town/mapper/TownMapper.java
@@ -20,10 +20,8 @@ import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface TownMapper {
-    // 타운 코드 중복 체크 메서드
-    Long selectIdByTownCode(String townCode);
-    // 타운 삽입
-    int insertTown(TownCreateRequestDTO townCreateRequestDTO);
-    // 멤버에 타운아이디 업데이트
-    int updateMemberTownId(@Param("townId") Long townId, @Param("memberId") Long memberId);
+    /** 타운 만들기 **/
+    Long selectIdByTownCode(String townCode);   // 타운 코드로 타운 ID 조회
+    int insertTown(TownCreateRequestDTO townCreateRequestDTO);  // 타운 삽입
+    int updateMemberTownId(@Param("townId") Long townId, @Param("memberId") Long memberId);   // 멤버에 타운아이디 업데이트
 }

--- a/src/main/java/com/themore/moamoatown/town/service/TownService.java
+++ b/src/main/java/com/themore/moamoatown/town/service/TownService.java
@@ -18,5 +18,5 @@ import com.themore.moamoatown.town.dto.TownCreateRequestDTO;
  */
 
 public interface TownService {
-    TownCreateInternalDTO createTown(TownCreateRequestDTO townCreateRequestDTO, Long memberId) throws Exception;
+    TownCreateInternalDTO createTown(TownCreateRequestDTO townCreateRequestDTO, Long memberId);
 }

--- a/src/main/java/com/themore/moamoatown/town/service/TownServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/town/service/TownServiceImpl.java
@@ -4,9 +4,10 @@ import com.themore.moamoatown.common.exception.CustomException;
 import com.themore.moamoatown.town.dto.TownCreateInternalDTO;
 import com.themore.moamoatown.town.dto.TownCreateRequestDTO;
 import com.themore.moamoatown.town.mapper.TownMapper;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
 import org.springframework.stereotype.Service;
+
 import static com.themore.moamoatown.common.exception.ErrorCode.*;
 
 /**
@@ -26,7 +27,7 @@ import static com.themore.moamoatown.common.exception.ErrorCode.*;
 
 @Log4j
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class TownServiceImpl implements TownService {
     private TownMapper townMapper;
 
@@ -49,7 +50,7 @@ public class TownServiceImpl implements TownService {
         Long townId = townCreateRequestDTO.getTownId();
 
         // 회원 테이블에 townId 업데이트
-        townMapper.updateMemberTownId(townId, memberId);
+        if(townMapper.updateMemberTownId(townId, memberId) < 0) throw new CustomException(TOWN_CREATE_FAILED);
 
         return TownCreateInternalDTO.builder()
                 .townId(townId)

--- a/src/main/java/com/themore/moamoatown/town/service/TownServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/town/service/TownServiceImpl.java
@@ -7,6 +7,7 @@ import com.themore.moamoatown.town.mapper.TownMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.themore.moamoatown.common.exception.ErrorCode.*;
 
@@ -29,8 +30,15 @@ import static com.themore.moamoatown.common.exception.ErrorCode.*;
 @Service
 @RequiredArgsConstructor
 public class TownServiceImpl implements TownService {
-    private TownMapper townMapper;
+    private final TownMapper townMapper;
 
+    /**
+     * 타운 만들기
+     * @param requestDTO
+     * @param memberId
+     * @return
+     */
+    @Transactional
     public TownCreateInternalDTO createTown(TownCreateRequestDTO requestDTO, Long memberId) {
         // 고유한 타운 코드 생성
         String townCode;

--- a/src/main/resources/com/themore/moamoatown/coordi/mapper/CoordiMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/coordi/mapper/CoordiMapper.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<!--
+ * 코디 매퍼 XML
+ * @version 1.0
+ * @since 2024.08.25
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ==========  ========     ===========================
+ * 2024.08.25   임원정       최초 생성
+ * </pre>
+-->
+<mapper namespace="com.themore.moamoatown.coordi.mapper.CoordiMapper">
+    <!-- 내 옷장의 옷 가져오기 -->
+    <select id="selectClothesByMemberId" resultType="MyClothesResponseDTO">
+        <![CDATA[
+        SELECT c.cloth_id, c.brand, c.name, c.type, c.img_url
+        FROM closet cl JOIN clothes c ON cl.cloth_id = c.cloth_id
+        WHERE member_id = #{memberId}
+        ]]>
+    </select>
+
+    <!-- 코디한 사진 프로필로 업데이트 -->
+    <update id="updateProfile">
+        <![CDATA[
+        UPDATE member
+        SET profile = #{profileImage}
+        WHERE member_id = #{memberId}
+        ]]>
+    </update>
+</mapper>

--- a/src/test/java/com/themore/moamoatown/coordi/CoordiServiceTests.java
+++ b/src/test/java/com/themore/moamoatown/coordi/CoordiServiceTests.java
@@ -1,0 +1,25 @@
+package com.themore.moamoatown.coordi;
+
+import com.themore.moamoatown.coordi.service.CoordiService;
+import lombok.extern.log4j.Log4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@WebAppConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = "file:**/*-context.xml")
+@Log4j
+public class CoordiServiceTests {
+    @Autowired
+    private CoordiService service;
+
+    @Test
+    public void testGetMyClothes() throws Exception {
+        log.info(service.getMyClothes(17L));
+    }
+}
+


### PR DESCRIPTION
###  작업한 내용
- 타운 생성 관련 주석 수정 및 불필요한 주석 삭제
- 내(로그인한 회원) 옷장 아이템 가져오기
<img width="444" alt="image" src="https://github.com/user-attachments/assets/55eceb4a-a119-4a0a-b65b-89c152cfdc05">

- 코디한 이미지로 프로필 업데이트
<img width="379" alt="image" src="https://github.com/user-attachments/assets/39948635-d8fe-45cc-98cf-efbe8c90d961">
<img width="892" alt="image" src="https://github.com/user-attachments/assets/04221486-8b16-4455-be55-48c39117f921">
DB에 profile 업데이트 된 거 확인