### PR TITLE
fix: 타운 생성한 멤버 역할 변경 누락 수정

### DIFF
--- a/src/main/java/com/themore/moamoatown/town/mapper/TownMapper.java
+++ b/src/main/java/com/themore/moamoatown/town/mapper/TownMapper.java
@@ -23,5 +23,5 @@ public interface TownMapper {
     /** 타운 만들기 **/
     Long selectIdByTownCode(String townCode);   // 타운 코드로 타운 ID 조회
     int insertTown(TownCreateRequestDTO townCreateRequestDTO);  // 타운 삽입
-    int updateMemberTownId(@Param("townId") Long townId, @Param("memberId") Long memberId);   // 멤버에 타운아이디 업데이트
+    int updateMember(@Param("townId") Long townId, @Param("memberId") Long memberId);   // 멤버의 타운아이디 및 역할 업데이트
 }

--- a/src/main/java/com/themore/moamoatown/town/service/TownServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/town/service/TownServiceImpl.java
@@ -58,7 +58,7 @@ public class TownServiceImpl implements TownService {
         Long townId = townCreateRequestDTO.getTownId();
 
         // 회원 테이블에 townId 업데이트
-        if(townMapper.updateMemberTownId(townId, memberId) < 0) throw new CustomException(TOWN_CREATE_FAILED);
+        if(townMapper.updateMember(townId, memberId) != 1) throw new CustomException(TOWN_CREATE_FAILED);
 
         return TownCreateInternalDTO.builder()
                 .townId(townId)

--- a/src/main/resources/com/themore/moamoatown/town/mapper/TownMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/town/mapper/TownMapper.xml
@@ -33,11 +33,12 @@
         ]]>
     </insert>
 
-    <!-- 타운 만들기_생성한 회원에게 townId 넣어주기 -->
-    <update id="updateMemberTownId" parameterType="map">
+    <!-- 타운 만들기_생성한 회원에게 townId와 role 업데이트 -->
+    <update id="updateMember">
         <![CDATA[
         UPDATE member
-        SET town_id = #{townId}
+        SET town_id = #{townId},
+            role = 1
         WHERE member_id = #{memberId}
         ]]>
     </update>


### PR DESCRIPTION
###  작업한 내용
- 타운 생성 시 멤버의 역할 변경이 누락되어 추가

타운 생성 전
![image](https://github.com/user-attachments/assets/bfd3f4e2-f1be-4884-8d1a-93db2d436546)

타운 생성 후
<img width="863" alt="image" src="https://github.com/user-attachments/assets/962c3603-e15b-4eea-b3c7-2653aed7b748">

