### PR TITLE
refactor: 타운 내 역할 요청 리스트 조회 job 도메인으로 이동

### DIFF
--- a/src/main/java/com/themore/moamoatown/job/controller/JobController.java
+++ b/src/main/java/com/themore/moamoatown/job/controller/JobController.java
@@ -6,6 +6,7 @@ import com.themore.moamoatown.job.dto.JobRequestDTO;
 import com.themore.moamoatown.job.dto.JobRequestResponseDTO;
 import com.themore.moamoatown.job.dto.JobResponseDTO;
 import com.themore.moamoatown.job.service.JobService;
+import com.themore.moamoatown.job.dto.JobRequestsResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +28,7 @@ import java.util.List;
  * 2024.08.26   임재성        역할 리스트 조회 기능 추가
  * 2024.08.26   임재성        역할 리스트 조회 메서드 수정
  * 2024.08.26   임재성        역할 요청 기능 추가
+ * 2024.08.26   임원정        타운 역할 신청 현황 조회 추가
  * </pre>
  */
 @RestController
@@ -85,5 +87,16 @@ public class JobController {
 
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 타운 내 역할 신청 현황 조회
+     * @param townId
+     * @return
+     */
+    @GetMapping("/requests")
+    public ResponseEntity<List<JobRequestsResponseDTO>> getJobRequests(@TownId Long townId) {
+        List<JobRequestsResponseDTO> response = jobService.getJobRequests(townId);
+        return ResponseEntity.ok(response);
     }
+}
 

--- a/src/main/java/com/themore/moamoatown/job/dto/JobRequestsResponseDTO.java
+++ b/src/main/java/com/themore/moamoatown/job/dto/JobRequestsResponseDTO.java
@@ -1,4 +1,4 @@
-package com.themore.moamoatown.town.dto;
+package com.themore.moamoatown.job.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/themore/moamoatown/job/mapper/JobMapper.java
+++ b/src/main/java/com/themore/moamoatown/job/mapper/JobMapper.java
@@ -2,6 +2,7 @@ package com.themore.moamoatown.job.mapper;
 
 import com.themore.moamoatown.job.dto.JobRequestDTO;
 import com.themore.moamoatown.job.dto.JobResponseDTO;
+import com.themore.moamoatown.job.dto.JobRequestsResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -16,12 +17,13 @@ import java.util.List;
  * @version 1.0
  *
  * <pre>
- * 수정일        	수정자        수정내용
+ * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.26  	임재성        최초 생성
  * 2024.08.26   임재성        역할 리스트 조회 기능 추가
  * 2024.08.26   임재성        역할 리스트 조회 메서드 수정
  * 2024.08.26   임재성        역할 요청 기능 추가
+ * 2024.08.26   임원정        타운 역할 신청 현황 조회
  * </pre>
  */
 @Mapper
@@ -39,4 +41,7 @@ public interface JobMapper {
      * @param jobRequestDTO 역할 요청 정보
      */
     void insertJobRequest(JobRequestDTO jobRequestDTO);
+
+    /** 타운 역할 신청 현황 조회 **/
+    List<JobRequestsResponseDTO> selectJobRequestByTownId(Long townId);
 }

--- a/src/main/java/com/themore/moamoatown/job/service/JobService.java
+++ b/src/main/java/com/themore/moamoatown/job/service/JobService.java
@@ -3,6 +3,7 @@ package com.themore.moamoatown.job.service;
 import com.themore.moamoatown.job.dto.JobRequestDTO;
 import com.themore.moamoatown.job.dto.JobRequestResponseDTO;
 import com.themore.moamoatown.job.dto.JobResponseDTO;
+import com.themore.moamoatown.job.dto.JobRequestsResponseDTO;
 
 import java.util.List;
 
@@ -20,6 +21,7 @@ import java.util.List;
  * 2024.08.26   임재성        역할 리스트 조회 기능 추가
  * 2024.08.26   임재성        역할 리스트 조회 메서드 수정
  * 2024.08.26   임재성        역할 요청 기능 추가
+ * 2024.08.26   임원정        getJobRequests 메소드 추가
  * </pre>
  */
 public interface JobService {
@@ -37,4 +39,6 @@ public interface JobService {
      * @return 역할 요청 처리 결과
      */
     JobRequestResponseDTO requestJob(JobRequestDTO jobRequestDTO);
+
+    List<JobRequestsResponseDTO> getJobRequests(Long townId);
 }

--- a/src/main/java/com/themore/moamoatown/job/service/JobServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/job/service/JobServiceImpl.java
@@ -4,12 +4,14 @@ import com.themore.moamoatown.job.dto.JobRequestDTO;
 import com.themore.moamoatown.job.dto.JobRequestResponseDTO;
 import com.themore.moamoatown.job.dto.JobResponseDTO;
 import com.themore.moamoatown.job.mapper.JobMapper;
-import com.themore.moamoatown.job.service.JobService;
+import com.themore.moamoatown.job.dto.JobRequestsResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * JOB 관련 비즈니스 로직을 처리하는 서비스 구현체 클래스.
@@ -25,6 +27,7 @@ import java.util.List;
  * 2024.08.26   임재성        역할 리스트 조회 기능 추가
  * 2024.08.26   임재성        역할 리스트 조회 메서드 수정
  * 2024.08.26   임재성        역할 요청 기능 추가
+ * 2024.08.26   임원정        타운 내 역할 신청 현황 조회 메소드 추가
  * </pre>
  */
 @Log4j
@@ -40,6 +43,7 @@ public class JobServiceImpl implements JobService {
 
         return jobMapper.findJobsByTownId(townId);
     }
+
     @Override
     public JobRequestResponseDTO requestJob(JobRequestDTO jobRequestDTO) {
         log.info("역할 요청 처리 중 - Job ID: " + jobRequestDTO.getJobId() + ", Member ID: " + jobRequestDTO.getMemberId());
@@ -49,5 +53,26 @@ public class JobServiceImpl implements JobService {
         return JobRequestResponseDTO.builder()
                 .message("역할 요청이 성공적으로 처리되었습니다.")
                 .build();
+    }
+
+    /**
+     * 타운 내 역할 신청 현황 조회
+     * @param townId
+     * @return
+     */
+    @Override
+    @Transactional
+    public List<JobRequestsResponseDTO> getJobRequests(Long townId){
+
+        return jobMapper.selectJobRequestByTownId(townId)
+                .stream()
+                .map(jobRequest -> JobRequestsResponseDTO.builder()
+                        .jobRequestId(jobRequest.getJobRequestId())
+                        .name(jobRequest.getName())
+                        .comments(jobRequest.getComments())
+                        .nickName(jobRequest.getNickName())
+                        .allowYN(jobRequest.getAllowYN())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/themore/moamoatown/town/controller/TownController.java
+++ b/src/main/java/com/themore/moamoatown/town/controller/TownController.java
@@ -2,7 +2,10 @@ package com.themore.moamoatown.town.controller;
 
 import com.themore.moamoatown.common.annotation.MemberId;
 import com.themore.moamoatown.common.annotation.TownId;
-import com.themore.moamoatown.town.dto.*;
+import com.themore.moamoatown.town.dto.TownCreateInternalDTO;
+import com.themore.moamoatown.town.dto.TownCreateRequestDTO;
+import com.themore.moamoatown.town.dto.TownCreateResponseDTO;
+import com.themore.moamoatown.town.dto.TownTaxResponseDTO;
 import com.themore.moamoatown.town.service.TownService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
@@ -10,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpSession;
-import java.util.List;
 
 /**
  * 타운 컨트롤러
@@ -25,7 +27,6 @@ import java.util.List;
  * 2024.08.23   임원정        타운 만들기 추가
  * 2024.08.24   임원정        타운 만들기 메소드 수정
  * 2024.08.26   임원정        타운 세금 현황 조회 추가
- * 2024.08.26   임원정        타운 역할 신청 현황 조회 추가
  * </pre>
  */
 
@@ -69,17 +70,6 @@ public class TownController {
     @GetMapping("/tax")
     public ResponseEntity<TownTaxResponseDTO> getTotalTax(@TownId Long townId) {
         TownTaxResponseDTO response = townService.getTotalTax(townId);
-        return ResponseEntity.ok(response);
-    }
-
-    /**
-     * 타운 역할 신쳥 현황 조회
-     * @param townId
-     * @return
-     */
-    @GetMapping("/job/request")
-    public ResponseEntity<List<JobRequestsResponseDTO>> getJobRequests(@TownId Long townId) {
-        List<JobRequestsResponseDTO> response = townService.getJobRequests(townId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/themore/moamoatown/town/mapper/TownMapper.java
+++ b/src/main/java/com/themore/moamoatown/town/mapper/TownMapper.java
@@ -1,12 +1,9 @@
 package com.themore.moamoatown.town.mapper;
 
-import com.themore.moamoatown.town.dto.JobRequestsResponseDTO;
 import com.themore.moamoatown.town.dto.TownCreateRequestDTO;
 import com.themore.moamoatown.town.dto.TownTaxResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-
-import java.util.List;
 
 /**
  * 타운 매퍼 인터페이스
@@ -20,7 +17,6 @@ import java.util.List;
  * 2024.08.23  	임원정        최초 생성
  * 2024.08.23  	임원정        타운 만들기 기능 추가
  * 2024.08.26   임원정        타운 세금 현황 조회 추가
- * 2024.08.26   임원정       타운 역할 신청 현황 조회 메소드 추가
  * </pre>
  */
 
@@ -34,6 +30,5 @@ public interface TownMapper {
     /** 타운 세금 현황 조회 **/
     TownTaxResponseDTO selectTotalTaxByTownId(Long townId);
 
-    /** 타운 역할 신청 현황 조회**/
-    List<JobRequestsResponseDTO> selectJobRequestByTownId(Long townId);
+
 }

--- a/src/main/java/com/themore/moamoatown/town/service/TownService.java
+++ b/src/main/java/com/themore/moamoatown/town/service/TownService.java
@@ -1,11 +1,8 @@
 package com.themore.moamoatown.town.service;
 
-import com.themore.moamoatown.town.dto.JobRequestsResponseDTO;
 import com.themore.moamoatown.town.dto.TownCreateInternalDTO;
 import com.themore.moamoatown.town.dto.TownCreateRequestDTO;
 import com.themore.moamoatown.town.dto.TownTaxResponseDTO;
-
-import java.util.List;
 
 /**
  * 타운 서비스 인터페이스
@@ -19,12 +16,10 @@ import java.util.List;
  * 2024.08.23  	임원정        최초 생성
  * 2024.08.23   임원정        createTown 메소드 추가
  * 2024.08.26   임원정        getTotalTax 메소드 추가
- * 2024.08.26   임원정        getJobRequests 메소드 추가
  * </pre>
  */
 
 public interface TownService {
     TownCreateInternalDTO createTown(TownCreateRequestDTO townCreateRequestDTO, Long memberId);
     TownTaxResponseDTO getTotalTax(Long townId);
-    List<JobRequestsResponseDTO> getJobRequests(Long townId);
 }

--- a/src/main/java/com/themore/moamoatown/town/service/TownServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/town/service/TownServiceImpl.java
@@ -1,7 +1,6 @@
 package com.themore.moamoatown.town.service;
 
 import com.themore.moamoatown.common.exception.CustomException;
-import com.themore.moamoatown.town.dto.JobRequestsResponseDTO;
 import com.themore.moamoatown.town.dto.TownCreateInternalDTO;
 import com.themore.moamoatown.town.dto.TownCreateRequestDTO;
 import com.themore.moamoatown.town.dto.TownTaxResponseDTO;
@@ -10,9 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.themore.moamoatown.common.exception.ErrorCode.TOWN_CREATE_FAILED;
 
@@ -29,7 +25,6 @@ import static com.themore.moamoatown.common.exception.ErrorCode.TOWN_CREATE_FAIL
  * 2024.08.23   임원정        타운 만들기 추가
  * 2024.08.24   임원정        타운 만들기 메소드 수정
  * 2024.08.26   임원정        타운 세금 현황 조회 추가
- * 2024.08.26   임원정        타운 역할 신청 현황 조회 메소드 추가
  * </pre>
  */
 
@@ -87,24 +82,4 @@ public class TownServiceImpl implements TownService {
                 .build();
     }
 
-    /**
-     * 타운 내 역할 신쳥 현황 조회
-     * @param townId
-     * @return
-     */
-    @Override
-    @Transactional
-    public List<JobRequestsResponseDTO> getJobRequests(Long townId){
-
-        return townMapper.selectJobRequestByTownId(townId)
-                .stream()
-                .map(jobRequest -> JobRequestsResponseDTO.builder()
-                        .jobRequestId(jobRequest.getJobRequestId())
-                        .name(jobRequest.getName())
-                        .comments(jobRequest.getComments())
-                        .nickName(jobRequest.getNickName())
-                        .allowYN(jobRequest.getAllowYN())
-                        .build())
-                .collect(Collectors.toList());
-    }
 }

--- a/src/main/resources/com/themore/moamoatown/job/mapper/JobMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/job/mapper/JobMapper.xml
@@ -1,7 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-
+<!--
+ * 역할 매퍼 XML
+ * @version 1.0
+ * @since 2024.08.26
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ==========  ========     ===========================
+ * 2024.08.26   임재성       최초 생성
+ * 2024.08.26   임재성        역할 리스트 조회 기능 추가
+ * 2024.08.26   임재성        역할 리스트 조회 메서드 수정
+ * 2024.08.26   임재성        역할 요청 기능 추가
+ * 2024.08.26   임원정        타운 역할 신청 현황 조회
+ * </pre>
+-->
 <mapper namespace="com.themore.moamoatown.job.mapper.JobMapper">
 
     <!-- 타운 ID에 따른 JOB 목록 조회 -->
@@ -25,4 +39,16 @@
         VALUES (JOB_REQUEST_SEQ.NEXTVAL, #{jobId}, #{memberId}, #{comments}, 'N')
         ]]>
     </insert>
+
+    <!-- 타운 내 역할 신청 현황 조회 -->
+    <select id="selectJobRequestByTownId" resultType="JobRequestsResponseDTO">
+        <![CDATA[
+            SELECT jr.job_request_id, j.name, jr.comments, m.nickname, jr.allowYN
+            FROM job j
+                     JOIN job_request jr ON j.job_id = jr.job_id
+                     JOIN member m ON jr.member_id = m.member_id
+            WHERE j.town_id = #{townId}
+            ORDER BY jr.created_at DESC
+        ]]>
+    </select>
 </mapper>

--- a/src/main/resources/com/themore/moamoatown/town/mapper/TownMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/town/mapper/TownMapper.xml
@@ -13,7 +13,6 @@
  * 2024.08.23   임원정       타운 만들기 관련 메소드 추가
  * 2024.08.24   임원정       타운 아이디 가져오기 함수 수정
  * 2024.08.26   임원정       타운 세금현황 조회 메소드 추가
- * 2024.08.26   임원정       타운 역할 신청 현황 조회 메소드 추가
  * </pre>
 -->
 <mapper namespace="com.themore.moamoatown.town.mapper.TownMapper">
@@ -51,17 +50,6 @@
         SELECT total_tax
         FROM town
         WHERE town_id = #{townId}
-        ]]>
-    </select>
-
-    <!-- 타운 역할 신청 현황 조회 -->
-    <select id="selectJobRequestByTownId" resultType="JobRequestsResponseDTO">
-        <![CDATA[
-        SELECT jr.job_request_id, j.name, jr.comments, m.nickname, jr.allowYN
-        FROM job j
-                 JOIN job_request jr ON j.job_id = jr.job_id
-                 JOIN member m ON jr.member_id = m.member_id
-        WHERE j.town_id = #{townId}
         ]]>
     </select>
 </mapper>


### PR DESCRIPTION
###  작업한 내용
- town 도메인 내 있던 역할 신청 리스트 조회 api를 job 도메인으로 옮겼습니다.
- 이동 후 테스트 완료
<img width="563" alt="image" src="https://github.com/user-attachments/assets/95e99789-75f3-4fa8-8b32-b21debfb0111">