### PR TITLE
feat: 퀘스트 현황 리스트 조회 추가

### DIFF
--- a/src/main/java/com/themore/moamoatown/quest/controller/QuestController.java
+++ b/src/main/java/com/themore/moamoatown/quest/controller/QuestController.java
@@ -5,6 +5,7 @@ import com.themore.moamoatown.common.annotation.MemberId;
 import com.themore.moamoatown.common.annotation.TownId;
 import com.themore.moamoatown.quest.dto.QuestCreateRequestDTO;
 import com.themore.moamoatown.quest.dto.QuestResponseDTO;
+import com.themore.moamoatown.quest.dto.QuestStatusListResponseDTO;
 import com.themore.moamoatown.quest.service.QuestService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +25,7 @@ import java.util.List;
  * ----------  --------    ---------------------------
  * 2024.08.26  이주현        최초 생성
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
- * 2024.08.27  임원정        퀘스트 만들기 추가
+ * 2024.08.27  임원정        퀘스트 만들기, 퀘스트 현황 조회 추가
  * </pre>
  */
 
@@ -70,5 +71,17 @@ public class QuestController {
     public ResponseEntity<String> createQuest(@RequestBody QuestCreateRequestDTO requestDTO, @TownId Long townId) {
         questService.createQuest(requestDTO, townId);
         return ResponseEntity.ok("퀘스트 생성에 성공했습니다.");
+    }
+
+    /**
+     * 퀘스트 현황 리스트 조회
+     * @param townId
+     * @return
+     */
+    @Auth(role = Auth.Role.MAYER)
+    @GetMapping("/status")
+    public ResponseEntity<List<QuestStatusListResponseDTO>> getQuestStatusList(@TownId Long townId) {
+        List<QuestStatusListResponseDTO> response = questService.getQuestStatusList(townId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/themore/moamoatown/quest/dto/QuestStatusListResponseDTO.java
+++ b/src/main/java/com/themore/moamoatown/quest/dto/QuestStatusListResponseDTO.java
@@ -1,0 +1,33 @@
+package com.themore.moamoatown.quest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 퀘스트 현황 조회 Response DTO
+ * @author 임원정
+ * @since 2024.08.27
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.27  	임원정        최초 생성
+ * </pre>
+ */
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuestStatusListResponseDTO {
+    private Long questId;
+    private String title;
+    private Long reward;
+    private String deadline;
+    private Long requestCnt;
+    private Long selectedCnt;
+    private Long capacity;
+}

--- a/src/main/java/com/themore/moamoatown/quest/mapper/QuestMapper.java
+++ b/src/main/java/com/themore/moamoatown/quest/mapper/QuestMapper.java
@@ -2,6 +2,7 @@ package com.themore.moamoatown.quest.mapper;
 
 import com.themore.moamoatown.quest.dto.QuestCreateRequestDTO;
 import com.themore.moamoatown.quest.dto.QuestResponseDTO;
+import com.themore.moamoatown.quest.dto.QuestStatusListResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -18,7 +19,7 @@ import java.util.List;
  * ----------  --------    ---------------------------
  * 2024.08.26  이주현        최초 생성
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
- * 2024.08.26  임원정        insertQuest 메소드 추가
+ * 2024.08.27  임원정        insertQuest, selectQuestStatusListByTownId 메소드 추가
  * </pre>
  */
 
@@ -31,4 +32,6 @@ public interface QuestMapper {
     int insertMemberQuest(@Param("memberId") Long memberId, @Param("questId") Long questId);
     // 퀘스트 생성
     int insertQuest(QuestCreateRequestDTO questCreateRequestDTO);
+    // 퀘스트 현황 리스트 조회
+    List<QuestStatusListResponseDTO> selectQuestStatusListByTownId(Long townId);
 }

--- a/src/main/java/com/themore/moamoatown/quest/service/QuestService.java
+++ b/src/main/java/com/themore/moamoatown/quest/service/QuestService.java
@@ -2,6 +2,7 @@ package com.themore.moamoatown.quest.service;
 
 import com.themore.moamoatown.quest.dto.QuestCreateRequestDTO;
 import com.themore.moamoatown.quest.dto.QuestResponseDTO;
+import com.themore.moamoatown.quest.dto.QuestStatusListResponseDTO;
 
 import java.util.List;
 
@@ -16,7 +17,7 @@ import java.util.List;
  * ----------  --------    ---------------------------
  * 2024.08.26  이주현        최초 생성
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
- * 2024.08.27  임원정        퀘스트 생성 추가
+ * 2024.08.27  임원정        퀘스트 생성, 퀘스트 현황 리스트 추가
  * </pre>
  */
 
@@ -28,4 +29,6 @@ public interface QuestService {
     void addMemberQuest(Long memberId, Long questId);
     // 퀘스트 생성
     void createQuest(QuestCreateRequestDTO requestDTO, Long townId);
+    // 퀘스트 현황 리스트 조회
+    List<QuestStatusListResponseDTO> getQuestStatusList(Long townId);
 }

--- a/src/main/java/com/themore/moamoatown/quest/service/QuestServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/quest/service/QuestServiceImpl.java
@@ -3,9 +3,11 @@ package com.themore.moamoatown.quest.service;
 import com.themore.moamoatown.common.exception.CustomException;
 import com.themore.moamoatown.quest.dto.QuestCreateRequestDTO;
 import com.themore.moamoatown.quest.dto.QuestResponseDTO;
+import com.themore.moamoatown.quest.dto.QuestStatusListResponseDTO;
 import com.themore.moamoatown.quest.mapper.QuestMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,7 +25,7 @@ import static com.themore.moamoatown.common.exception.ErrorCode.*;
  * ----------  --------    ---------------------------
  * 2024.08.26  이주현        최초 생성
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
- * 2024.08.27  임원정        퀘스트 생성 추가
+ * 2024.08.27  임원정        퀘스트 생성, 퀘스트 현황 리스트 조회 추가
  * </pre>
  */
 
@@ -69,6 +71,7 @@ public class QuestServiceImpl implements QuestService {
      * @param questId
      */
     @Override
+    @Transactional
     public void addMemberQuest(Long memberId, Long questId) {
         int insertedRows = questMapper.insertMemberQuest(memberId, questId);
         if (insertedRows < 1) {
@@ -82,6 +85,7 @@ public class QuestServiceImpl implements QuestService {
      * @param townId
      */
     @Override
+    @Transactional
     public void createQuest(QuestCreateRequestDTO requestDTO, Long townId) {
         QuestCreateRequestDTO questCreateRequestDTO = QuestCreateRequestDTO.builder()
                 .title(requestDTO.getTitle())
@@ -92,5 +96,26 @@ public class QuestServiceImpl implements QuestService {
                 .townId(townId)
                 .build();
         if(questMapper.insertQuest(questCreateRequestDTO) != 1) throw new CustomException(QUEST_CREATE_FAILED);
+    }
+
+    /**
+     * 퀘스트 현황 리스트 조회
+     * @param townId
+     * @return
+     */
+    @Override
+    public List<QuestStatusListResponseDTO> getQuestStatusList(Long townId) {
+        return questMapper.selectQuestStatusListByTownId(townId)
+                .stream()
+                .map(questStatus -> QuestStatusListResponseDTO.builder()
+                        .questId(questStatus.getQuestId())
+                        .title(questStatus.getTitle())
+                        .reward(questStatus.getReward())
+                        .deadline(questStatus.getDeadline())
+                        .requestCnt(questStatus.getRequestCnt())
+                        .selectedCnt(questStatus.getSelectedCnt())
+                        .capacity(questStatus.getCapacity())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/resources/com/themore/moamoatown/quest/mapper/QuestMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/quest/mapper/QuestMapper.xml
@@ -13,7 +13,7 @@
 * ==========  ========     ===========================
 * 2024.08.26  이주현        최초 생성
 * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
-* 2024.08.26  임원정        insertQuest 메소드 추가
+* 2024.08.26  임원정        insertQuest, selectQuestStatusListByTownId 메소드 추가
 * </pre>
 -->
 
@@ -57,4 +57,16 @@
             VALUES (QUEST_SEQ.NEXTVAL, #{townId}, #{title}, #{description}, #{reward}, #{capacity}, TO_DATE(#{deadline}, 'YYYY-MM-DD'))
         ]]>
     </insert>
+
+    <!-- 퀘스트 현황 조회 -->
+    <select id="selectQuestStatusListByTownId" resultType="QuestStatusListResponseDTO">
+        <![CDATA[
+            SELECT q.quest_id, q.title, q.reward, TO_CHAR(q.deadline, 'YYYY.MM.DD') as deadline, COUNT(mq.member_quest_id) as request_cnt, COUNT(DECODE(mq.selectedyn, 'Y', 1, NULL)) as selected_cnt, q.capacity
+            FROM quest q
+            LEFT JOIN member_quest mq ON q.quest_id = mq.quest_id
+            WHERE q.town_id = #{townId}
+            GROUP BY q.quest_id, q.title, q.reward, TO_CHAR(q.deadline, 'YYYY.MM.DD'), q.capacity
+            ORDER BY deadline DESC
+        ]]>
+    </select>
 </mapper>


### PR DESCRIPTION
###  작업한 내용
- 퀘스트 현황 리스트 조회_ requestCnt : 신청한 인원의 수, selectedCnt : 선정된 인원의 수, capacity : 퀘스트 수행 인원

### 테스트
<img width="536" alt="image" src="https://github.com/user-attachments/assets/c8e5e1e0-ec2d-476f-86a6-90e544e79ed9">
