### PR TITLE
feat: 퀘스트 요청 조회 추가

### DIFF
--- a/src/main/java/com/themore/moamoatown/quest/controller/QuestController.java
+++ b/src/main/java/com/themore/moamoatown/quest/controller/QuestController.java
@@ -3,6 +3,7 @@ package com.themore.moamoatown.quest.controller;
 import com.themore.moamoatown.common.annotation.Auth;
 import com.themore.moamoatown.common.annotation.MemberId;
 import com.themore.moamoatown.common.annotation.TownId;
+import com.themore.moamoatown.quest.dto.MemberQuestRequestsResponseDTO;
 import com.themore.moamoatown.quest.dto.QuestCreateRequestDTO;
 import com.themore.moamoatown.quest.dto.QuestResponseDTO;
 import com.themore.moamoatown.quest.dto.QuestStatusListResponseDTO;
@@ -82,6 +83,18 @@ public class QuestController {
     @GetMapping("/status")
     public ResponseEntity<List<QuestStatusListResponseDTO>> getQuestStatusList(@TownId Long townId) {
         List<QuestStatusListResponseDTO> response = questService.getQuestStatusList(townId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 퀘스트 요청 조회
+     * @param questId
+     * @return
+     */
+    @Auth(role = Auth.Role.MAYER)
+    @GetMapping("/requests/{questId}")
+    public ResponseEntity<List<MemberQuestRequestsResponseDTO>> getMemberQuestRequests(@PathVariable Long questId) {
+        List<MemberQuestRequestsResponseDTO> response = questService.getMemberQuests(questId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/themore/moamoatown/quest/dto/MemberQuestRequestsResponseDTO.java
+++ b/src/main/java/com/themore/moamoatown/quest/dto/MemberQuestRequestsResponseDTO.java
@@ -1,0 +1,29 @@
+package com.themore.moamoatown.quest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 퀘스트 요청 리스트 조회 Response DTO
+ * @author 임원정
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.28  	임원정        최초 생성
+ * </pre>
+ */
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberQuestRequestsResponseDTO {
+    private Long memberQuestId;
+    private String nickName;
+    private Long status;
+}

--- a/src/main/java/com/themore/moamoatown/quest/mapper/QuestMapper.java
+++ b/src/main/java/com/themore/moamoatown/quest/mapper/QuestMapper.java
@@ -1,5 +1,6 @@
 package com.themore.moamoatown.quest.mapper;
 
+import com.themore.moamoatown.quest.dto.MemberQuestRequestsResponseDTO;
 import com.themore.moamoatown.quest.dto.QuestCreateRequestDTO;
 import com.themore.moamoatown.quest.dto.QuestResponseDTO;
 import com.themore.moamoatown.quest.dto.QuestStatusListResponseDTO;
@@ -20,6 +21,7 @@ import java.util.List;
  * 2024.08.26  이주현        최초 생성
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
  * 2024.08.27  임원정        insertQuest, selectQuestStatusListByTownId 메소드 추가
+ * 2024.08.28  임원정        selectMemberQuestByQuestId 메소드 추가
  * </pre>
  */
 
@@ -34,4 +36,6 @@ public interface QuestMapper {
     int insertQuest(QuestCreateRequestDTO questCreateRequestDTO);
     // 퀘스트 현황 리스트 조회
     List<QuestStatusListResponseDTO> selectQuestStatusListByTownId(Long townId);
+    // 퀘스트 신청 조회
+    List<MemberQuestRequestsResponseDTO> selectMemberQuestByQuestId(Long questId);
 }

--- a/src/main/java/com/themore/moamoatown/quest/service/QuestService.java
+++ b/src/main/java/com/themore/moamoatown/quest/service/QuestService.java
@@ -1,5 +1,6 @@
 package com.themore.moamoatown.quest.service;
 
+import com.themore.moamoatown.quest.dto.MemberQuestRequestsResponseDTO;
 import com.themore.moamoatown.quest.dto.QuestCreateRequestDTO;
 import com.themore.moamoatown.quest.dto.QuestResponseDTO;
 import com.themore.moamoatown.quest.dto.QuestStatusListResponseDTO;
@@ -18,6 +19,7 @@ import java.util.List;
  * 2024.08.26  이주현        최초 생성
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
  * 2024.08.27  임원정        퀘스트 생성, 퀘스트 현황 리스트 추가
+ * 2024.08.28   임원정       퀘스트 요청 조회 추가
  * </pre>
  */
 
@@ -31,4 +33,6 @@ public interface QuestService {
     void createQuest(QuestCreateRequestDTO requestDTO, Long townId);
     // 퀘스트 현황 리스트 조회
     List<QuestStatusListResponseDTO> getQuestStatusList(Long townId);
+    // 퀘스트 요청(memberQuest) 조회
+    List<MemberQuestRequestsResponseDTO> getMemberQuests(Long questId);
 }

--- a/src/main/java/com/themore/moamoatown/quest/service/QuestServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/quest/service/QuestServiceImpl.java
@@ -1,6 +1,7 @@
 package com.themore.moamoatown.quest.service;
 
 import com.themore.moamoatown.common.exception.CustomException;
+import com.themore.moamoatown.quest.dto.MemberQuestRequestsResponseDTO;
 import com.themore.moamoatown.quest.dto.QuestCreateRequestDTO;
 import com.themore.moamoatown.quest.dto.QuestResponseDTO;
 import com.themore.moamoatown.quest.dto.QuestStatusListResponseDTO;
@@ -26,6 +27,7 @@ import static com.themore.moamoatown.common.exception.ErrorCode.*;
  * 2024.08.26  이주현        최초 생성
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
  * 2024.08.27  임원정        퀘스트 생성, 퀘스트 현황 리스트 조회 추가
+ * 2024.08.28   임원정       퀘스트 요청 조회 추가
  * </pre>
  */
 
@@ -115,6 +117,23 @@ public class QuestServiceImpl implements QuestService {
                         .requestCnt(questStatus.getRequestCnt())
                         .selectedCnt(questStatus.getSelectedCnt())
                         .capacity(questStatus.getCapacity())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 퀘스트 요청 조회
+     * @param questId
+     * @return
+     */
+    @Override
+    public List<MemberQuestRequestsResponseDTO> getMemberQuests(Long questId) {
+        return questMapper.selectMemberQuestByQuestId(questId)
+                .stream()
+                .map(memberQuest -> MemberQuestRequestsResponseDTO.builder()
+                        .memberQuestId(memberQuest.getMemberQuestId())
+                        .nickName(memberQuest.getNickName())
+                        .status(memberQuest.getStatus())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/src/main/resources/com/themore/moamoatown/quest/mapper/QuestMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/quest/mapper/QuestMapper.xml
@@ -13,7 +13,8 @@
 * ==========  ========     ===========================
 * 2024.08.26  이주현        최초 생성
 * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
-* 2024.08.26  임원정        insertQuest, selectQuestStatusListByTownId 메소드 추가
+* 2024.08.27  임원정        insertQuest, selectQuestStatusListByTownId 메소드 추가
+* 2024.08.28  임원정        selectMemberQuestByQuestId 메소드 추가
 * </pre>
 -->
 
@@ -67,6 +68,23 @@
             WHERE q.town_id = #{townId}
             GROUP BY q.quest_id, q.title, q.reward, TO_CHAR(q.deadline, 'YYYY.MM.DD'), q.capacity
             ORDER BY deadline DESC
+        ]]>
+    </select>
+
+    <!-- 퀘스트 ID로 member_quest 찾기 -->
+    <select id="selectMemberQuestByQuestId" resultType="MemberQuestRequestsResponseDTO">
+    <![CDATA[
+        SELECT
+            mq.member_quest_id,
+            m.nickname,
+            CASE
+                WHEN mq.endYN = 'Y' THEN 3  -- 퀘스트 완료: 3
+                WHEN mq.selectedYN = 'Y' THEN 2  -- 퀘스트 수락: 2
+                ELSE 1 -- 수락 대기 중: 1
+                END AS status
+        FROM member_quest mq
+        LEFT JOIN member m ON mq.member_id = m.member_id
+        WHERE mq.quest_id = #{questId}
         ]]>
     </select>
 </mapper>


### PR DESCRIPTION
###  작업한 내용
- 퀘스트 아이디에 따른 퀘스트 요청 조회
- status : WHEN mq.endYN = 'Y' THEN 3  -- 퀘스트 완료: 3
                WHEN mq.selectedYN = 'Y' THEN 2  -- 퀘스트 수락: 2
                ELSE 1 -- 수락 대기 중: 1

### 테스트
<img width="471" alt="image" src="https://github.com/user-attachments/assets/3020410c-6f40-4e8c-a2d4-205e24601e1b">

