### PR TITLE
feat: 퀘스트 완료 처리 추가

### DIFF
--- a/src/main/java/com/themore/moamoatown/common/exception/ErrorCode.java
+++ b/src/main/java/com/themore/moamoatown/common/exception/ErrorCode.java
@@ -44,7 +44,8 @@ public enum ErrorCode {
     WISH_DELETE_FAILED(INTERNAL_SERVER_ERROR, "위시 삭제에 실패했습니다."),
     WISH_COMPLETE_FAILED(INTERNAL_SERVER_ERROR, "위시 상품 완료 처리에 실패했습니다."),
     QUEST_CREATE_FAILED(BAD_REQUEST, "퀘스트 만들기에 실패했습니다."),
-    QUEST_SELECTED_FAILED(INTERNAL_SERVER_ERROR, "퀘스트 담당자 선정이 완료되었습니다.")
+    QUEST_SELECTED_FAILED(INTERNAL_SERVER_ERROR, "퀘스트 담당자 선정에 실패했습니다."),
+    QUEST_COMPLETE_FAILED(INTERNAL_SERVER_ERROR, "퀘스트 완료 처리에 실패했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/themore/moamoatown/quest/controller/QuestController.java
+++ b/src/main/java/com/themore/moamoatown/quest/controller/QuestController.java
@@ -27,7 +27,8 @@ import java.util.List;
  * 2024.08.26  이주현        최초 생성
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
  * 2024.08.27  임원정        퀘스트 만들기, 퀘스트 현황 조회 추가
- * 2024.08.28   임원정       퀘스트 요청 조회, 퀘스트 요청 수락 추가
+ * 2024.08.28  임원정        퀘스트 요청 조회, 퀘스트 요청 수락 추가
+ * 2024.08.28  임원정        퀘스트 완료 처리 추가
  * </pre>
  */
 
@@ -111,4 +112,15 @@ public class QuestController {
         return ResponseEntity.ok("회원의 퀘스트 요청이 수락되었습니다.");
     }
 
+    /**
+     * 퀘스트 완료 처리
+     * @param memberQuestId
+     * @return
+     */
+    @Auth(role = Auth.Role.MAYER)
+    @PostMapping("/complete/{memberQuestId}")
+    public ResponseEntity<String> completeMemberQuest(@PathVariable Long memberQuestId){
+        questService.completeMemberQuest(memberQuestId);
+        return ResponseEntity.ok("퀘스트가 완료처리 되었습니다.");
+    }
 }

--- a/src/main/java/com/themore/moamoatown/quest/mapper/QuestMapper.java
+++ b/src/main/java/com/themore/moamoatown/quest/mapper/QuestMapper.java
@@ -22,6 +22,7 @@ import java.util.List;
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
  * 2024.08.27  임원정        insertQuest, selectQuestStatusListByTownId 메소드 추가
  * 2024.08.28  임원정        selectMemberQuestByQuestId, updateMemberQuestSelected 메소드 추가
+ * 2024.08.28  임원정        callCompleteQuestProcedure 메소드 추가
  * </pre>
  */
 
@@ -40,4 +41,6 @@ public interface QuestMapper {
     List<MemberQuestRequestsResponseDTO> selectMemberQuestByQuestId(Long questId);
     // 퀘스트 수행인 선정
     int updateMemberQuestSelected(Long memberQuestId);
+    // 퀘스트 완료 처리
+    void callCompleteQuestProcedure(Long memberQuestId);
 }

--- a/src/main/java/com/themore/moamoatown/quest/service/QuestService.java
+++ b/src/main/java/com/themore/moamoatown/quest/service/QuestService.java
@@ -19,7 +19,8 @@ import java.util.List;
  * 2024.08.26  이주현        최초 생성
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
  * 2024.08.27  임원정        퀘스트 생성, 퀘스트 현황 리스트 추가
- * 2024.08.28   임원정       퀘스트 요청 조회, 퀘스트 수행인 선정 추가
+ * 2024.08.28  임원정        퀘스트 요청 조회, 퀘스트 수행인 선정 추가
+ * 2024.08.28  임원정        퀘스트 요청 완료 처리 추가
  * </pre>
  */
 
@@ -37,4 +38,6 @@ public interface QuestService {
     List<MemberQuestRequestsResponseDTO> getMemberQuests(Long questId);
     // 퀘스트 수행인 선정
     void updateMemberQuestSelected(Long memberQuestId);
+    // 퀘스트 요청 완료 처리
+    void completeMemberQuest(Long memberQuestId);
 }

--- a/src/main/java/com/themore/moamoatown/quest/service/QuestServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/quest/service/QuestServiceImpl.java
@@ -7,6 +7,7 @@ import com.themore.moamoatown.quest.dto.QuestResponseDTO;
 import com.themore.moamoatown.quest.dto.QuestStatusListResponseDTO;
 import com.themore.moamoatown.quest.mapper.QuestMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,7 +28,8 @@ import static com.themore.moamoatown.common.exception.ErrorCode.*;
  * 2024.08.26  이주현        최초 생성
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
  * 2024.08.27  임원정        퀘스트 생성, 퀘스트 현황 리스트 조회 추가
- * 2024.08.28   임원정       퀘스트 요청 조회, 퀘스트 수행인 선정 추가
+ * 2024.08.28  임원정        퀘스트 요청 조회, 퀘스트 수행인 선정 추가
+ * 2024.08.28  임원정        퀘스트 요청 완료 처리 추가
  * </pre>
  */
 
@@ -145,5 +147,19 @@ public class QuestServiceImpl implements QuestService {
     @Override
     public void updateMemberQuestSelected(Long memberQuestId) {
         if(questMapper.updateMemberQuestSelected(memberQuestId) < 1) throw new CustomException(QUEST_SELECTED_FAILED);
+    }
+
+    /**
+     * 멤버 퀘스트 완료 처리
+     * @param memberQuestId
+     */
+    @Override
+    @Transactional
+    public void completeMemberQuest(Long memberQuestId) {
+        try {
+            questMapper.callCompleteQuestProcedure(memberQuestId);
+        } catch (DataAccessException e) {
+            throw new CustomException(QUEST_COMPLETE_FAILED);
+        }
     }
 }

--- a/src/main/resources/com/themore/moamoatown/quest/mapper/QuestMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/quest/mapper/QuestMapper.xml
@@ -15,6 +15,7 @@
 * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
 * 2024.08.27  임원정        insertQuest, selectQuestStatusListByTownId 메소드 추가
 * 2024.08.28  임원정        selectMemberQuestByQuestId, updateMemberQuestSelected 메소드 추가
+* 2024.08.28  임원정        callCompleteQuestProcedure 메소드 추가
 * </pre>
 -->
 
@@ -96,4 +97,9 @@
             WHERE member_quest_id = #{memberQuestId}
         ]]>
     </update>
+
+    <!-- 퀘스트 완료 처리_프로시저 호출 -->
+    <select id="callCompleteQuestProcedure" statementType="CALLABLE">
+        {CALL complete_quest(#{memberQuestId, jdbcType=NUMERIC})}
+    </select>
 </mapper>


### PR DESCRIPTION
###  작업한 내용
- complete_quest 프로시저 추가
```
-- 퀘스트 완료 처리 프로시저 추가
CREATE PROCEDURE complete_quest (
    -- 파라미터 변수
    p_member_quest_id IN NUMBER
) AS
    -- 로컬 변수
    l_member_id   NUMBER;
    l_quest_id    NUMBER;
    l_reward      NUMBER;
BEGIN
    -- 1. MEMBER_QUEST 테이블에서 완료 요청된 멤버 퀘스트의 회원 ID,퀘스트 ID, 보상 가져오기
    SELECT mq.member_id, mq.quest_id, q.reward
    INTO l_member_id, l_quest_id, l_reward
    FROM member_quest mq
    JOIN quest q ON mq.quest_id = q.quest_id
    WHERE mq.member_quest_id = p_member_quest_id
      AND mq.endyn = 'N';

    -- 2. MEMBER_QUEST 테이블의 endYN 컬럼을 'Y'로 업데이트 => 완료 처리
    UPDATE member_quest
    SET endyn = 'Y'
    WHERE member_quest_id = p_member_quest_id;

    -- 3. ACCOUNT 테이블에 거래 내역 추가 (type 3 : 퀘스트 보상)
    INSERT INTO account (account_id, trade_date, moa, type, member_id)
    VALUES (ACCOUNT_SEQ.NEXTVAL, SYSDATE, l_reward, 3, l_member_id);

    COMMIT;
EXCEPTION
    WHEN NO_DATA_FOUND THEN
        RAISE_APPLICATION_ERROR(-20001, '퀘스트 완료 처리 중 오류가 발생했습니다: 데이터가 없습니다.');
    WHEN OTHERS THEN
        ROLLBACK;
        RAISE_APPLICATION_ERROR(-20002, '퀘스트 완료 처리 중 오류가 발생했습니다: ' || SQLERRM);
END complete_quest;
/
```
- 퀘스트 완료 기능 추가

### 테스트
 - 퀘스트 완료 되어있지 않은 상태 -> 완료 처리 /  퀘스트 완료 되어있는 상태 -> exception 발생
<img height="300" src="https://github.com/user-attachments/assets/6e3d3e41-af72-4870-95f4-7477ec7ae998">
<img height="300" src="https://github.com/user-attachments/assets/3c3e2e29-6d02-4b7f-9c87-7ca838f53193">

 - member_quest 테이블 endYN = 'Y'로 변경

![image](https://github.com/user-attachments/assets/37376ec3-2da6-4df6-8121-b0478c2b1832)
 - account 테이블에 type 3으로 보상금액 추가

![image](https://github.com/user-attachments/assets/6fb6ef31-d816-456e-bcac-0f70f22a0436)


