### PR TITLE
Feat/notification/ 알림 구독 및 전송 기능 추가

### DIFF
--- a/src/main/java/com/themore/moamoatown/job/mapper/JobMapper.java
+++ b/src/main/java/com/themore/moamoatown/job/mapper/JobMapper.java
@@ -24,6 +24,7 @@ import java.util.List;
  * 2024.08.26   임재성        역할 리스트 조회 메서드 수정
  * 2024.08.26   임재성        역할 요청 기능 추가
  * 2024.08.26   임원정        selectJobRequestByTownId, insertJob, updateJobRequestAllowed 추가
+ * 2024.08.28   임원정        findMemberIdByJobRequestId 추가
  * </pre>
  */
 @Mapper
@@ -49,4 +50,6 @@ public interface JobMapper {
     int insertJob(JobCreateRequestDTO jobCreateRequestDTO);
     // 역할 요청 승인
     int updateJobRequestAllowed(Long jobRequestId);
+    // 역할 승인된 회원 ID 조회
+    Long findMemberIdByJobRequestId(Long jobRequestId);
 }

--- a/src/main/java/com/themore/moamoatown/job/service/JobServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/job/service/JobServiceImpl.java
@@ -3,6 +3,7 @@ package com.themore.moamoatown.job.service;
 import com.themore.moamoatown.common.exception.CustomException;
 import com.themore.moamoatown.job.dto.*;
 import com.themore.moamoatown.job.mapper.JobMapper;
+import com.themore.moamoatown.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,7 @@ import static com.themore.moamoatown.common.exception.ErrorCode.*;
  * 2024.08.26   임재성        역할 리스트 조회 메서드 수정
  * 2024.08.26   임재성        역할 요청 기능 추가
  * 2024.08.26   임원정        getJobRequests, createJob, allowJobRequest 추가
+ * 2024.08.28  임원정         알림 전송 로직 추가
  * </pre>
  */
 @Log4j
@@ -37,6 +39,7 @@ import static com.themore.moamoatown.common.exception.ErrorCode.*;
 public class JobServiceImpl implements JobService {
 
     private final JobMapper jobMapper;
+    private final NotificationService notificationService;
     /**
      * 타운 ID를 통해 JOB 리스트를 조회합니다.
      * @param townId 타운 ID
@@ -113,5 +116,11 @@ public class JobServiceImpl implements JobService {
     @Transactional
     public void allowJobRequest(Long jobRequestId) {
         if(jobMapper.updateJobRequestAllowed(jobRequestId) != 1) throw new CustomException(JOB_REQUEST_ALLOW_FAILED);
+        // 역할이 승인된 회원 정보 조회
+        Long memberId = jobMapper.findMemberIdByJobRequestId(jobRequestId);
+
+        // 알림 전송
+        String content = "축하합니다! 요청하신 역할에 선정되었습니다.";
+        notificationService.notifyMember(memberId, content, "job");
     }
 }

--- a/src/main/java/com/themore/moamoatown/member/mapper/MemberMapper.java
+++ b/src/main/java/com/themore/moamoatown/member/mapper/MemberMapper.java
@@ -24,6 +24,7 @@ import java.util.List;
  * 2024.08.26  이주현        멤버 역할 조회
  * 2024.08.26  이주현        멤버 타운 조회
  * 2024.08.26  이주현        멤버 계좌 조회
+ * 2024.08.28  임원정        타운 관리자 조회 기능 추가
  * </pre>
  */
 
@@ -68,4 +69,7 @@ public interface MemberMapper {
 
     // 멤버 계좌 조회
     List<MemberAccountResponseDTO> findAccountsByMemberIdWithPaging(MemberAccountInternalDTO internalDTO);
+
+    // 타운 관리자 조회
+    Long findAdminByTownId(Long townId);
 }

--- a/src/main/java/com/themore/moamoatown/notification/controller/NotificationController.java
+++ b/src/main/java/com/themore/moamoatown/notification/controller/NotificationController.java
@@ -1,0 +1,46 @@
+package com.themore.moamoatown.notification.controller;
+
+import com.themore.moamoatown.common.annotation.Auth;
+import com.themore.moamoatown.common.annotation.MemberId;
+import com.themore.moamoatown.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * 알림 컨트롤러
+ * @author 임원정
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.28  	임원정        최초 생성
+ * 2024.08.28   임원정        알림 구독 추가
+ * </pre>
+ */
+
+@Log4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value="/notification",
+        produces = "application/json; charset=UTF-8")
+@Auth(role = Auth.Role.CITIZEN)
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    /**
+     * 알림 구독
+     * @param memberId
+     * @return
+     */
+    @GetMapping("/subscribe")
+    public SseEmitter subscribe(@MemberId Long memberId) {
+        return notificationService.subscribe(memberId);
+    }
+}

--- a/src/main/java/com/themore/moamoatown/notification/dto/NotificationDTO.java
+++ b/src/main/java/com/themore/moamoatown/notification/dto/NotificationDTO.java
@@ -1,0 +1,27 @@
+package com.themore.moamoatown.notification.dto;
+
+import lombok.*;
+
+/**
+ * 알림 DTO
+ * @author 임원정
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.28  	임원정        최초 생성
+ * </pre>
+ */
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationDTO {
+    private Long notificationId;
+    private String content;
+    private String createdAt;
+    private Long memberId;
+}

--- a/src/main/java/com/themore/moamoatown/notification/dto/NotificationInsertDTO.java
+++ b/src/main/java/com/themore/moamoatown/notification/dto/NotificationInsertDTO.java
@@ -1,0 +1,28 @@
+package com.themore.moamoatown.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 알림 DB 저장옹 DTO
+ * @author 임원정
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.28  	임원정        최초 생성
+ * </pre>
+ */
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationInsertDTO {
+    private Long memberId;
+    private String content;
+}

--- a/src/main/java/com/themore/moamoatown/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/themore/moamoatown/notification/mapper/NotificationMapper.java
@@ -1,0 +1,20 @@
+package com.themore.moamoatown.notification.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * 알림 Mapper
+ * @author 임원정
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.28  	임원정        최초 생성
+ * </pre>
+ */
+
+@Mapper
+public interface NotificationMapper {
+}

--- a/src/main/java/com/themore/moamoatown/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/themore/moamoatown/notification/mapper/NotificationMapper.java
@@ -1,5 +1,6 @@
 package com.themore.moamoatown.notification.mapper;
 
+import com.themore.moamoatown.notification.dto.NotificationInsertDTO;
 import org.apache.ibatis.annotations.Mapper;
 
 /**
@@ -12,9 +13,11 @@ import org.apache.ibatis.annotations.Mapper;
  * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.28  	임원정        최초 생성
+ * 2024.08.28   임원정        insertNotification 메소드 추가
  * </pre>
  */
 
 @Mapper
 public interface NotificationMapper {
+    void insertNotification(NotificationInsertDTO notificationInsertDTO);
 }

--- a/src/main/java/com/themore/moamoatown/notification/service/NotificationService.java
+++ b/src/main/java/com/themore/moamoatown/notification/service/NotificationService.java
@@ -1,0 +1,22 @@
+package com.themore.moamoatown.notification.service;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * 알림 서비스
+ * @author 임원정
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.28  	임원정        최초 생성
+ * 2024.08.28   임원정        알림 구독 추가
+ * </pre>
+ */
+
+public interface NotificationService {
+    // 알림 구독
+    SseEmitter subscribe(Long memberId);
+}

--- a/src/main/java/com/themore/moamoatown/notification/service/NotificationService.java
+++ b/src/main/java/com/themore/moamoatown/notification/service/NotificationService.java
@@ -12,11 +12,13 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
  * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.28  	임원정        최초 생성
- * 2024.08.28   임원정        알림 구독 추가
+ * 2024.08.28   임원정        알림 구독, 회원에게 알림 전송 추가
  * </pre>
  */
 
 public interface NotificationService {
     // 알림 구독
     SseEmitter subscribe(Long memberId);
+    // 회원에게 알림 전송
+    void notifyMember(Long memberId, String content, String eventType);
 }

--- a/src/main/java/com/themore/moamoatown/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,54 @@
+package com.themore.moamoatown.notification.service;
+
+import com.themore.moamoatown.notification.mapper.NotificationMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * 알림 서비스 구현체
+ * @author 임원정
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.28  	임원정        최초 생성
+ * 2024.08.28   임원정        알림 구독 추가
+ * </pre>
+ */
+
+@Log4j
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+    private final ConcurrentMap<Long, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
+    private final NotificationMapper notificationMapper;
+
+    // 타임아웃 설정 (5분)
+    private static final Long TIMEOUT = 300_000L;
+
+    /**
+     * 알림 구독
+     * @param memberId
+     * @return
+     */
+    @Override
+    public SseEmitter subscribe(Long memberId) {
+        SseEmitter emitter = new SseEmitter(TIMEOUT);
+        sseEmitters.put(memberId, emitter);
+
+        emitter.onCompletion(() -> sseEmitters.remove(memberId));
+        emitter.onTimeout(() -> {
+            log.info("SSE connection timeout for memberId: " + memberId);
+            sseEmitters.remove(memberId);
+        });
+
+        return emitter;
+    }
+}

--- a/src/main/java/com/themore/moamoatown/quest/mapper/QuestMapper.java
+++ b/src/main/java/com/themore/moamoatown/quest/mapper/QuestMapper.java
@@ -22,7 +22,7 @@ import java.util.List;
  * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
  * 2024.08.27  임원정        insertQuest, selectQuestStatusListByTownId 메소드 추가
  * 2024.08.28  임원정        selectMemberQuestByQuestId, updateMemberQuestSelected 메소드 추가
- * 2024.08.28  임원정        callCompleteQuestProcedure 메소드 추가
+ * 2024.08.28  임원정        callCompleteQuestProcedure, findMemberIdByMemberQuestId 메소드 추가
  * </pre>
  */
 
@@ -43,4 +43,6 @@ public interface QuestMapper {
     int updateMemberQuestSelected(Long memberQuestId);
     // 퀘스트 완료 처리
     void callCompleteQuestProcedure(Long memberQuestId);
+    // 퀘스트 요청 또는 완료 시 회원 ID 조회
+    Long findMemberIdByMemberQuestId(Long memberQuestId);
 }

--- a/src/main/java/com/themore/moamoatown/wish/controller/WishController.java
+++ b/src/main/java/com/themore/moamoatown/wish/controller/WishController.java
@@ -65,7 +65,8 @@ public class WishController {
     @PostMapping("/wishlist/purchase")
     public ResponseEntity<WishItemPurchaseResponseDTO> purchaseWishItem(
             @RequestBody WishItemPurchaseRequestDTO requestDTO,
-            @MemberId Long memberId // @MemberId 어노테이션으로 세션에서 memberId를 가져옴
+            @MemberId Long memberId, // @MemberId 어노테이션으로 세션에서 memberId를 가져옴
+            @TownId Long townId
     ) {
         log.info("위시 아이템 ID: " + requestDTO.getWishId() + "에 대한 구매 요청 처리 중");
 
@@ -76,7 +77,7 @@ public class WishController {
                 .build();
 
         // requestDTO로부터 wishId와 memberId를 이용해 처리
-        WishItemPurchaseResponseDTO response = wishService.purchaseWishItem(requestDTO);
+        WishItemPurchaseResponseDTO response = wishService.purchaseWishItem(requestDTO, townId);
 
         log.info("구매 완료 - " + response.getMessage());
 

--- a/src/main/java/com/themore/moamoatown/wish/service/WishService.java
+++ b/src/main/java/com/themore/moamoatown/wish/service/WishService.java
@@ -37,7 +37,7 @@ public interface WishService {
      * @param requestDTO 위시 상품 구매 요청 DTO.
      * @return 구매 결과 메시지를 포함한 응답 DTO.
      */
-    WishItemPurchaseResponseDTO purchaseWishItem(WishItemPurchaseRequestDTO requestDTO);
+    WishItemPurchaseResponseDTO purchaseWishItem(WishItemPurchaseRequestDTO requestDTO, Long townId);
     // 위시 상품 생성
     void createWishItem(WishItemCreateRequestDTO requestDTO, Long townId);
     // 위시 상품 삭제

--- a/src/main/resources/com/themore/moamoatown/job/mapper/JobMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/job/mapper/JobMapper.xml
@@ -18,6 +18,7 @@
  * 2024.08.26   임재성        역할 리스트 조회 메서드 수정
  * 2024.08.26   임재성        역할 요청 기능 추가
  * 2024.08.26   임원정        selectJobRequestByTownId, insertJob, updateJobRequestAllowed 추가
+ * 2024.08.28   임원정        findMemberIdByJobRequestId 추가
  * </pre>
 -->
 
@@ -73,4 +74,13 @@
             WHERE job_request_id = #{jobRequestId}
         ]]>
     </update>
+
+    <!-- 역할 승인된 회원 ID 조회 -->
+    <select id="findMemberIdByJobRequestId" resultType="java.lang.Long">
+        <![CDATA[
+            SELECT member_id
+            FROM job_request
+            WHERE job_request_id = #{jobRequestId}
+        ]]>
+    </select>
 </mapper>

--- a/src/main/resources/com/themore/moamoatown/member/mapper/MemberMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/member/mapper/MemberMapper.xml
@@ -21,6 +21,7 @@
 * 2024.08.26  이주현        멤버 역할 조회
 * 2024.08.26  이주현        멤버 타운 조회
 * 2024.08.26  이주현        멤버 계좌 조회
+* 2024.08.28  임원정        타운 관리자 조회 기능 추가
 * </pre>
 -->
 
@@ -173,4 +174,11 @@
         ]]>
     </select>
 
+    <!-- 타운 ID로 타운 관리자 ID 조회 -->
+    <select id="findAdminByTownId" resultType="Long">
+        SELECT member_id
+        FROM member
+        WHERE town_id = #{townId}
+        AND role = 1
+    </select>
 </mapper>

--- a/src/main/resources/com/themore/moamoatown/notification/mapper/NotificationMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/notification/mapper/NotificationMapper.xml
@@ -11,8 +11,14 @@
  * 수정일        수정자        수정내용
  * ==========  ========     ===========================
  * 2024.08.28   임원정       최초 생성
+ * 2024.08.28   임원정       insertNotification 메소드 추가
  * </pre>
 -->
 
 <mapper namespace="com.themore.moamoatown.notification.mapper.NotificationMapper">
+    <!-- 알림 저장 -->
+    <insert id="insertNotification">
+        INSERT INTO member_notifications (notification_id, content, created_at, member_id)
+        VALUES (MEMBER_NOTIFICATIONS_SEQ.NEXTVAL, #{content}, SYSDATE, #{memberId})
+    </insert>
 </mapper>

--- a/src/main/resources/com/themore/moamoatown/notification/mapper/NotificationMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/notification/mapper/NotificationMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+ * 알림 매퍼 XML
+ * @version 1.0
+ * @since 2024.08.28
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ==========  ========     ===========================
+ * 2024.08.28   임원정       최초 생성
+ * </pre>
+-->
+
+<mapper namespace="com.themore.moamoatown.notification.mapper.NotificationMapper">
+</mapper>

--- a/src/main/resources/com/themore/moamoatown/quest/mapper/QuestMapper.xml
+++ b/src/main/resources/com/themore/moamoatown/quest/mapper/QuestMapper.xml
@@ -15,7 +15,7 @@
 * 2024.08.26  이주현        퀘스트 수락 요청 기능 추가
 * 2024.08.27  임원정        insertQuest, selectQuestStatusListByTownId 메소드 추가
 * 2024.08.28  임원정        selectMemberQuestByQuestId, updateMemberQuestSelected 메소드 추가
-* 2024.08.28  임원정        callCompleteQuestProcedure 메소드 추가
+* 2024.08.28  임원정        callCompleteQuestProcedure, findMemberIdByMemberQuestId 메소드 추가
 * </pre>
 -->
 
@@ -101,5 +101,14 @@
     <!-- 퀘스트 완료 처리_프로시저 호출 -->
     <select id="callCompleteQuestProcedure" statementType="CALLABLE">
         {CALL complete_quest(#{memberQuestId, jdbcType=NUMERIC})}
+    </select>
+
+    <!-- 퀘스트 요청 또는 완료 시 회원 ID 조회 -->
+    <select id="findMemberIdByMemberQuestId" resultType="Long">
+        <![CDATA[
+            SELECT member_id
+            FROM member_quest
+            WHERE member_quest_id = #{memberQuestId}
+        ]]>
     </select>
 </mapper>


### PR DESCRIPTION
###  작업한 내용
- 알림 구독 API 추가
- 알림 전송 로직 추가
  - 시민 알림 : 역할 신청 승인 시, 퀘스트 신청 승인 시, 퀘스트 완료 처리 시
  - 시장 알림 : 시민이 위시 상품 구매 시

### 테스트
아직 알림 구독 및 클라이언트 구현이 없어 반환 값을 보여줄 수가 없어 DB 캡처본으로 대체합니다..^^
포스트맨으로 각 요청 보냈을 시 MEMBER_NOTIFCATION 테이블에 아주 차곡차곡 알림이 쌓이네요 @~~
<img width="724" alt="image" src="https://github.com/user-attachments/assets/8859331b-24e1-4cf6-92e3-d37f2acf32e4">


