### PR TITLE
fix: 프로필 base64 인코딩 삭제

### DIFF
--- a/src/main/java/com/themore/moamoatown/closet/service/ClosetServiceImpl.java
+++ b/src/main/java/com/themore/moamoatown/closet/service/ClosetServiceImpl.java
@@ -81,10 +81,8 @@ public class ClosetServiceImpl implements ClosetService {
     @Override
     public GetProfileResponseDTO getProfile(Long memberId) {
         GetProfileInternalDTO getProfileInternalDTO = closetMapper.selectProfileByMemberId(memberId);
-        // BLOB 데이터를 Base64로 인코딩
-        String base64Image = Base64.getEncoder().encodeToString(getProfileInternalDTO.getProfile());
         return GetProfileResponseDTO.builder()
-                .encodedProfileImage(base64Image)
+                .encodedProfileImage(new String(getProfileInternalDTO.getProfile()))
                 .build();
     }
 }


### PR DESCRIPTION
###  작업한 내용
- 죄송합니다. 바보처럼 base64 인코딩한 이미지를 다시 base64 인코딩 했습니다. 잘 불러와집니다.

<img width="290" alt="image" src="https://github.com/user-attachments/assets/cf0af382-d649-4c90-8f2e-aa7509c26b3d">

