### PR TITLE
refator: 타운아이디 -1, role 1인 경우 대응할 수 있도록 변환

### DIFF
--- a/src/main/java/com/themore/moamoatown/common/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/themore/moamoatown/common/interceptor/AuthInterceptor.java
@@ -88,15 +88,16 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
     }
 
     private Auth.Role mapRole(Long role, Long townId) {
-        // townId가 -1이면 권한 없음
-        if (townId == -1L) {
-            return null; // 권한 없음
-        }
-
-        if (role == 1L) {
-            return Auth.Role.MAYOR;
-        } else {
+        if (role == 0L){
+            // townId가 -1이면 권한 없음
+            if (townId == -1L) {
+                return null;
+            }
             return Auth.Role.CITIZEN;
         }
+        else if (role == 1L) {
+            return Auth.Role.MAYOR;
+        }
+        else return null;
     }
 }


### PR DESCRIPTION
###  작업한 내용
- 기존 : townId == -1이면 권한 없음
- 변경 : townId == -1이지만 시장 권한인 사람은 시장 권한 주도록 변경

현재 권한 시스템
(1) 시민 선택 후 회원가입 시 role == 0,  townId == -1 => 권한 없음
(2) 타운 참여 시 role == 0, townId != -1 => 시민
(3) 시장 선택 후 회원가입 시 role ==1, townId 상관없이 => 시장